### PR TITLE
Feat/fuzzy k8s version matching

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -19,7 +19,7 @@ resource "google_container_cluster" "cluster" {
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
-  min_master_version = local.kubernetes_version
+  min_master_version = data.google_container_engine_versions.location.latest_master_version
 
   # The API requires a node pool or an initial count to be defined; that initial count creates the
   # "default node pool" with that # of nodes.
@@ -105,8 +105,7 @@ resource "google_container_cluster" "cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  kubernetes_version = data.google_container_engine_versions.location.latest_master_version
-  network_project    = var.network_project != "" ? var.network_project : var.project
+  network_project = var.network_project != "" ? var.network_project : var.project
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -105,8 +105,7 @@ resource "google_container_cluster" "cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  latest_version     = data.google_container_engine_versions.location.latest_master_version
-  kubernetes_version = var.kubernetes_version != "latest" ? var.kubernetes_version : local.latest_version
+  kubernetes_version = data.google_container_engine_versions.location.latest_master_version
   network_project    = var.network_project != "" ? var.network_project : var.project
 }
 
@@ -116,6 +115,7 @@ locals {
 
 // Get available master versions in our location to determine the latest version
 data "google_container_engine_versions" "location" {
-  location = var.location
-  project  = var.project
+  location       = var.location
+  project        = var.project
+  version_prefix = var.kubernetes_version_prefix
 }

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -49,10 +49,10 @@ variable "description" {
   default     = ""
 }
 
-variable "kubernetes_version" {
-  description = "The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region."
+variable "kubernetes_version_prefix" {
+  description = "The Kubernetes version prefix of the master nodes (will string match the latest available). If unset it will default to latest available in given region."
   type        = string
-  default     = "latest"
+  default     = "null"
 }
 
 variable "logging_service" {
@@ -115,38 +115,38 @@ variable "master_authorized_networks_config" {
   }]
   
 EOF
-  type = list(any)
-  default = []
+  type        = list(any)
+  default     = []
 }
 
 variable "maintenance_start_time" {
   description = "Time window specified for daily maintenance operations in RFC3339 format"
-  type = string
-  default = "05:00"
+  type        = string
+  default     = "05:00"
 }
 
 variable "stub_domains" {
   description = "Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "non_masquerade_cidrs" {
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."
-  type = list(string)
-  default = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+  type        = list(string)
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 }
 
 variable "ip_masq_resync_interval" {
   description = "The interval at which the agent attempts to sync its ConfigMap file from the disk."
-  type = string
-  default = "60s"
+  type        = string
+  default     = "60s"
 }
 
 variable "ip_masq_link_local" {
   description = "Whether to masquerade traffic to the link-local prefix (169.254.0.0/16)."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -156,36 +156,36 @@ variable "ip_masq_link_local" {
 
 variable "enable_kubernetes_dashboard" {
   description = "Whether to enable the Kubernetes Web UI (Dashboard). The Web UI requires a highly privileged security account."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "enable_legacy_abac" {
   description = "Whether to enable legacy Attribute-Based Access Control (ABAC). RBAC has significant security advantages over ABAC."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "enable_network_policy" {
   description = "Whether to enable Kubernetes NetworkPolicy on the master, which is required to be enabled to be used on Nodes."
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "basic_auth_username" {
   description = "The username used for basic auth; set both this and `basic_auth_password` to \"\" to disable basic auth."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "basic_auth_password" {
   description = "The password used for basic auth; set both this and `basic_auth_username` to \"\" to disable basic auth."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "enable_client_certificate_authentication" {
   description = "Whether to enable authentication by x509 certificates. With ABAC disabled, these certificates are effectively useless."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
Fix for error when specific GKE version is no longer available for new clusters:
```shell
Error: googleapi: Error 400: Master version "1.13.6-gke.13" is unsupported., badRequest
```

This will now pick the latest supported by default, or string match the `kubernetes_version_prefix` variable to find the latest ([see docs here](https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html#version_prefix)).